### PR TITLE
Add "in_channels" parameter to Wavenet_Model

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -23,7 +23,7 @@ int main()
     auto nam_dsp = nam::get_dsp (model_path, model_data);
 
     wavenet::Wavenet_Model<float,
-                           1,
+                           1, 16,
                            wavenet::Layer_Array<float, 1, 1, 8, 16, 3, false, NAMMathsProvider, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512>,
                            wavenet::Layer_Array<float, 16, 1, 1, 8, 3, true, NAMMathsProvider, 1, 2, 4, 8, 16, 32, 64, 128, 256, 512>>
         rtneural_wavenet;

--- a/wavenet/wavenet_model.hpp
+++ b/wavenet/wavenet_model.hpp
@@ -6,11 +6,12 @@ namespace wavenet
 {
 template <typename T,
           int condition_size,
+          int in_channels,
           typename... LayerArrays>
 struct Wavenet_Model
 {
     std::tuple<LayerArrays...> layer_arrays;
-    Eigen::Matrix<T, 16, 1> head_input {};
+    Eigen::Matrix<T, in_channels, 1> head_input {};
     T head_scale = (T) 0;
 
     Wavenet_Model()
@@ -54,7 +55,7 @@ struct Wavenet_Model
                     if constexpr (index == 0)
                     {
                         head_input.setZero();
-                        Eigen::Map<Eigen::Matrix<T, 16, 1>, RTNeural::RTNeuralEigenAlignment> head_input_map { head_input.data() };
+                        Eigen::Map<Eigen::Matrix<T, in_channels, 1>, RTNeural::RTNeuralEigenAlignment> head_input_map { head_input.data() };
                         std::get<0> (layer_arrays).forward (v_ins, v_ins, head_input_map);
                     }
                     else


### PR DESCRIPTION
The number of channels of the input layer is currently effectively hardcoded to be 16. This makes it a template parameter of Wavenet_Model to allow other architectures.

It *may* be possible to extract this from the first layer of the network, but if so it is beyond my C++ template skills...